### PR TITLE
Improve Perlin noise and chunk cache

### DIFF
--- a/src/functions/debug/debug.c
+++ b/src/functions/debug/debug.c
@@ -51,7 +51,7 @@ void execute_debug_command(const char* cmd, Player* player) {
         if (sscanf(cmd + 3, "%d %d", &x, &y) == 2) {
             player->pos_x = x * TILE_SIZE;
             player->pos_y = y * TILE_SIZE;
-            debug_terminal_log("", x, y);
+            debug_terminal_log("    Teleportation a (%d %d)", x, y);
         } else {
             debug_terminal_log("    Syntaxe invalide : tp x y");
         }

--- a/src/functions/map/map.c
+++ b/src/functions/map/map.c
@@ -3,6 +3,32 @@
 static unsigned int usage_counter = 0;
 static Chunk chunk_cache[CHUNK_CACHE_SIZE];
 
+static int find_chunk_index(int chunk_x, int chunk_y) {
+    for (int i = 0; i < CHUNK_CACHE_SIZE; ++i) {
+        if (chunk_cache[i].loaded &&
+            chunk_cache[i].chunk_x == chunk_x &&
+            chunk_cache[i].chunk_y == chunk_y) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+static int find_free_or_lru(void) {
+    int lru_index = -1;
+    unsigned int oldest_use = ~0u;
+    for (int i = 0; i < CHUNK_CACHE_SIZE; ++i) {
+        if (!chunk_cache[i].loaded) {
+            return i;
+        }
+        if (chunk_cache[i].last_used < oldest_use) {
+            oldest_use = chunk_cache[i].last_used;
+            lru_index = i;
+        }
+    }
+    return lru_index;
+}
+
 const Chunk* get_chunk_cache(void) {
     return chunk_cache;
 }
@@ -43,13 +69,10 @@ TileID get_tile_at_cached(int global_x, int global_y) {
     int local_x = global_x % CHUNK_SIZE;
     int local_y = global_y % CHUNK_SIZE;
 
-    for (int i = 0; i < CHUNK_CACHE_SIZE; i++) {
-        if (chunk_cache[i].loaded &&
-            chunk_cache[i].chunk_x == chunk_x &&
-            chunk_cache[i].chunk_y == chunk_y) {
-            chunk_cache[i].last_used = ++usage_counter;
-            return chunk_cache[i].tiles[local_y][local_x];
-        }
+    int index = find_chunk_index(chunk_x, chunk_y);
+    if (index >= 0) {
+        chunk_cache[index].last_used = ++usage_counter;
+        return chunk_cache[index].tiles[local_y][local_x];
     }
     return 0;
 }
@@ -60,27 +83,13 @@ TileID get_tile_at(int global_x, int global_y) {
     int local_x = global_x % CHUNK_SIZE;
     int local_y = global_y % CHUNK_SIZE;
 
-    for (int i = 0; i < CHUNK_CACHE_SIZE; i++) {
-        if (chunk_cache[i].loaded &&
-            chunk_cache[i].chunk_x == chunk_x &&
-            chunk_cache[i].chunk_y == chunk_y) {
-            chunk_cache[i].last_used = ++usage_counter;
-            return chunk_cache[i].tiles[local_y][local_x];
-        }
+    int index = find_chunk_index(chunk_x, chunk_y);
+    if (index >= 0) {
+        chunk_cache[index].last_used = ++usage_counter;
+        return chunk_cache[index].tiles[local_y][local_x];
     }
 
-    int lru_index = -1;
-    unsigned int oldest_use = ~0u;
-    for (int i = 0; i < CHUNK_CACHE_SIZE; i++) {
-        if (!chunk_cache[i].loaded) {
-            lru_index = i;
-            break;
-        } else if (chunk_cache[i].last_used < oldest_use) {
-            oldest_use = chunk_cache[i].last_used;
-            lru_index = i;
-        }
-    }
-
+    int lru_index = find_free_or_lru();
     if (lru_index >= 0 && generate_chunk(chunk_cache[lru_index].tiles, chunk_x, chunk_y)) {
         chunk_cache[lru_index].chunk_x = chunk_x;
         chunk_cache[lru_index].chunk_y = chunk_y;
@@ -101,40 +110,19 @@ void Load_Chunks(int cam_tile_x, int cam_tile_y) {
             int target_chunk_x = cam_chunk_x + dx;
             int target_chunk_y = cam_chunk_y + dy;
 
-            // Vérifie si le chunk est déjà chargé
-            bool found = false;
-            for (int i = 0; i < CHUNK_CACHE_SIZE; i++) {
-                if (chunk_cache[i].loaded &&
-                    chunk_cache[i].chunk_x == target_chunk_x &&
-                    chunk_cache[i].chunk_y == target_chunk_y) {
-                    chunk_cache[i].last_used = ++usage_counter;
-                    found = true;
-                    break;
-                }
+            int index = find_chunk_index(target_chunk_x, target_chunk_y);
+            if (index >= 0) {
+                chunk_cache[index].last_used = ++usage_counter;
+                continue;
             }
 
-            // Sinon, charge un nouveau chunk à cette position
-            if (!found) {
-                int lru_index = -1;
-                unsigned int oldest_use = ~0u;
-                for (int i = 0; i < CHUNK_CACHE_SIZE; i++) {
-                    if (!chunk_cache[i].loaded) {
-                        lru_index = i;
-                        break;
-                    } else if (chunk_cache[i].last_used < oldest_use) {
-                        oldest_use = chunk_cache[i].last_used;
-                        lru_index = i;
-                    }
-                }
-
-                if (lru_index >= 0) {
-                    if (generate_chunk(chunk_cache[lru_index].tiles, target_chunk_x, target_chunk_y)) {
-                        chunk_cache[lru_index].chunk_x = target_chunk_x;
-                        chunk_cache[lru_index].chunk_y = target_chunk_y;
-                        chunk_cache[lru_index].loaded = true;
-                        chunk_cache[lru_index].last_used = ++usage_counter;
-                    }
-                }
+            int lru_index = find_free_or_lru();
+            if (lru_index >= 0 &&
+                generate_chunk(chunk_cache[lru_index].tiles, target_chunk_x, target_chunk_y)) {
+                chunk_cache[lru_index].chunk_x = target_chunk_x;
+                chunk_cache[lru_index].chunk_y = target_chunk_y;
+                chunk_cache[lru_index].loaded = true;
+                chunk_cache[lru_index].last_used = ++usage_counter;
             }
         }
     }

--- a/src/functions/map/map_noise.c
+++ b/src/functions/map/map_noise.c
@@ -1,12 +1,32 @@
+// Implementation of 2D Perlin noise with fBm helpers.
 #include <math.h>
 #include <stdlib.h>
 #include "../../include/global.h"
 
-// --- Bruit de base (comme avant) ---
-static float random2d(int x, int y) {
-    int n = x * 374761393 + y * 668265263;
-    n = (n ^ (n >> 13)) * 1274126177;
-    return (float)((n ^ (n >> 16)) & 0x7FFFFFFF) / 2147483647.0f;
+static const unsigned char base_perm[256] = {
+    151,160,137,91,90,15,131,13,201,95,96,53,194,233,7,225,140,36,103,30,
+    69,142,8,99,37,240,21,10,23,190,6,148,247,120,234,75,0,26,197,62,94,
+    252,219,203,117,35,11,32,57,177,33,88,237,149,56,87,174,20,125,136,171,
+    168,68,175,74,165,71,134,139,48,27,166,77,146,158,231,83,111,229,122,60,
+    211,133,230,220,105,92,41,55,46,245,40,244,102,143,54,65,25,63,161,1,
+    216,80,73,209,76,132,187,208,89,18,169,200,196,135,130,116,188,159,86,
+    164,100,109,198,173,186,3,64,52,217,226,250,124,123,5,202,38,147,118,
+    126,255,82,85,212,207,206,59,227,47,16,58,17,182,189,28,42,223,183,170,
+    213,119,248,152,2,44,154,163,70,221,153,101,155,167,43,172,9,129,22,39,
+    253,19,98,108,110,79,113,224,232,178,185,112,104,218,246,97,228,251,34,
+    242,193,238,210,144,12,191,179,162,241,81,51,145,235,249,14,239,107,49,
+    192,214,31,181,199,106,157,184,84,204,176,115,121,50,45,127,4,150,254,
+    138,236,205,93,222,114,67,29,24,72,243,141,128,195,78,66,215,61,156,180
+};
+
+static unsigned char perm[512];
+static int perm_initialized = 0;
+
+static void init_perm(void) {
+    for (int i = 0; i < 256; ++i) {
+        perm[i] = perm[256 + i] = base_perm[i];
+    }
+    perm_initialized = 1;
 }
 
 static float lerp(float a, float b, float t) {
@@ -17,53 +37,72 @@ static float fade(float t) {
     return t * t * t * (t * (t * 6 - 15) + 10);
 }
 
+static float grad(int hash, float x, float y) {
+    switch (hash & 7) {
+        case 0: return  x + y;
+        case 1: return -x + y;
+        case 2: return  x - y;
+        case 3: return -x - y;
+        case 4: return  x;
+        case 5: return -x;
+        case 6: return  y;
+        default: return -y;
+    }
+}
+
 float noise2d(float x, float y) {
-    int x0 = (int)floorf(x);
-    int y0 = (int)floorf(y);
-    int x1 = x0 + 1;
-    int y1 = y0 + 1;
+    if (!perm_initialized) init_perm();
 
-    float sx = fade(x - x0);
-    float sy = fade(y - y0);
+    int X = (int)floorf(x) & 255;
+    int Y = (int)floorf(y) & 255;
 
-    float n00 = random2d(x0, y0);
-    float n10 = random2d(x1, y0);
-    float n01 = random2d(x0, y1);
-    float n11 = random2d(x1, y1);
+    x -= floorf(x);
+    y -= floorf(y);
 
-    float ix0 = lerp(n00, n10, sx);
-    float ix1 = lerp(n01, n11, sx);
-    return lerp(ix0, ix1, sy);
+    float u = fade(x);
+    float v = fade(y);
+
+    int A = perm[X] + Y;
+    int B = perm[X + 1] + Y;
+
+    float res = lerp(
+        lerp(grad(perm[A], x, y),
+             grad(perm[B], x - 1, y), u),
+        lerp(grad(perm[A + 1], x, y - 1),
+             grad(perm[B + 1], x - 1, y - 1), u),
+        v);
+
+    return (res + 1.0f) * 0.5f; // normalisé [0,1]
 }
 
 float fbm(float x, float y, int octaves, float persistence, float scale) {
     float total = 0.0f;
     float amplitude = 1.0f;
     float max_value = 0.0f;
+    float frequency = scale;
 
     for (int i = 0; i < octaves; i++) {
-        total += noise2d(x * scale, y * scale) * amplitude;
+        total += noise2d(x * frequency, y * frequency) * amplitude;
         max_value += amplitude;
 
         amplitude *= persistence;
-        scale *= 2.0f;
+        frequency *= 2.0f;
     }
 
-    return total / max_value;
+    return max_value > 0.0f ? total / max_value : 0.0f;
 }
 
 NoiseSample get_noise_sample(int x, int y) {
     NoiseSample sample;
-    sample.x = x;
-    sample.y = y;
-    sample.elevation = fbm(x, y, 5, 0.5f, 0.01f);  // ou autre usage
+    sample.x = (float)x;
+    sample.y = (float)y;
+    sample.elevation = fbm((float)x, (float)y, 5, 0.5f, 0.01f);
     sample.humidity = noise2d(x * 0.05f, y * 0.05f);
     sample.temperature = noise2d((x + 5000) * 0.05f, (y + 5000) * 0.05f);
     return sample;
 }
 
 BiomeType get_biome_from_sample(NoiseSample sample) {
-    // Utiliser fBM sur la position pour une transition douce entre biomes
     float val = fbm(sample.x, sample.y, 5, 0.5f, 0.01f);
 
     if (val < 0.25f) return BIOME_DESERT;

--- a/src/functions/map/map_noise.h
+++ b/src/functions/map/map_noise.h
@@ -1,8 +1,7 @@
+// Noise generation helpers for map creation.
 #ifndef MAP_NOISE_H
 #define MAP_NOISE_H
 
-#include <stdbool.h>
-#include <SDL2/SDL.h>
 #include "../../include/structure.h"
 
 // Retourne une hauteur normalisée [0, 1] à une position (x, y)
@@ -22,3 +21,4 @@ float fbm(float x, float y, int octaves, float persistence, float scale);
 float noise2d(float x, float y);
 
 #endif
+

--- a/src/include/global.h
+++ b/src/include/global.h
@@ -6,12 +6,11 @@
 #include <string.h>
 #include <stdbool.h>
 
-extern bool debug_mode; // déclaration
-
 // === SDL ===
-#include <stdbool.h>
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_ttf.h>
+
+extern bool debug_mode; // déclaration
 
 // === Modules du jeu ===
 #include "../functions/character/character.h"


### PR DESCRIPTION
## Summary
- Replace value noise with true gradient-based Perlin noise and expose helper header
- Refactor chunk caching with reusable search/LRU helpers for better performance
- Fix debug teleport command formatting and streamline global header includes

## Testing
- `cmake -S . -B build` *(fails: Could not find SDL2 package)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6891a3cc5bb08333a8d9e3932bc1b696