### PR TITLE
Add biome system with large regions and colors

### DIFF
--- a/src/functions/elements/elements.c
+++ b/src/functions/elements/elements.c
@@ -13,6 +13,25 @@ static TileVariant forest_tiles[] = {
     { TILE_ROCK, 0.1f }
 };
 
+static TileVariant plains_tiles[] = {
+    { TILE_GRASS, 0.8f },
+    { TILE_SOIL, 0.2f }
+};
+
+static TileVariant snow_tiles[] = {
+    { TILE_SNOW, 0.8f },
+    { TILE_ROCK, 0.2f }
+};
+
+static TileVariant mountain_tiles[] = {
+    { TILE_ROCK, 0.7f },
+    { TILE_SNOW, 0.3f }
+};
+
+static TileVariant water_tiles[] = {
+    { TILE_WATER, 1.0f }
+};
+
 TileVariant get_tile_variant_for_biome(BiomeType biome, int x, int y) {
     float r = noise2d(x * 0.2f, y * 0.2f);
     TileVariant* variants = NULL;
@@ -26,6 +45,22 @@ TileVariant get_tile_variant_for_biome(BiomeType biome, int x, int y) {
         case BIOME_FOREST:
             variants = forest_tiles;
             count = sizeof(forest_tiles) / sizeof(TileVariant);
+            break;
+        case BIOME_PLAINS:
+            variants = plains_tiles;
+            count = sizeof(plains_tiles) / sizeof(TileVariant);
+            break;
+        case BIOME_SNOW:
+            variants = snow_tiles;
+            count = sizeof(snow_tiles) / sizeof(TileVariant);
+            break;
+        case BIOME_MOUNTAIN:
+            variants = mountain_tiles;
+            count = sizeof(mountain_tiles) / sizeof(TileVariant);
+            break;
+        case BIOME_WATER:
+            variants = water_tiles;
+            count = sizeof(water_tiles) / sizeof(TileVariant);
             break;
         default:
             return (TileVariant){ TILE_GRASS, 1.0f };

--- a/src/functions/map/map_noise.c
+++ b/src/functions/map/map_noise.c
@@ -117,6 +117,10 @@ float get_height(int x, int y) {
 }
 
 BiomeType get_biome_at(int x, int y) {
-    NoiseSample sample = get_noise_sample(x, y);
+    int bx = x / BIOME_SIZE;
+    int by = y / BIOME_SIZE;
+    int sample_x = bx * BIOME_SIZE;
+    int sample_y = by * BIOME_SIZE;
+    NoiseSample sample = get_noise_sample(sample_x, sample_y);
     return get_biome_from_sample(sample);
 }

--- a/src/functions/map/map_noise.h
+++ b/src/functions/map/map_noise.h
@@ -4,6 +4,8 @@
 
 #include "../../include/structure.h"
 
+#define BIOME_SIZE 200
+
 // Returns a normalized height [0, 1] at position (x, y)
 float get_height(int x, int y);
 

--- a/src/functions/ui/ui.c
+++ b/src/functions/ui/ui.c
@@ -71,8 +71,6 @@ void render_minimap(SDL_Renderer* renderer, float player_pos_x, float player_pos
                 if (dx < -RADIUS_TILES || dx > RADIUS_TILES || dy < -RADIUS_TILES || dy > RADIUS_TILES)
                     continue;
 
-                TileID tile = chunk_cache[i].tiles[y][x];
-
                 SDL_Rect rect = {
                     MARGIN_X + (dx + RADIUS_TILES) * TILE_PIXEL,
                     MARGIN_Y + (dy + RADIUS_TILES) * TILE_PIXEL,
@@ -80,7 +78,8 @@ void render_minimap(SDL_Renderer* renderer, float player_pos_x, float player_pos
                     TILE_PIXEL
                 };
 
-                set_tile_color(renderer ,tile);
+                BiomeType biome = get_biome_at(global_x, global_y);
+                set_biome_color(renderer, biome);
 
                 SDL_RenderFillRect(renderer, &rect);
             }
@@ -100,6 +99,11 @@ void render_minimap(SDL_Renderer* renderer, float player_pos_x, float player_pos
 
 void set_tile_color(SDL_Renderer* r, TileID tile) {
     SDL_Color c = tile_colors[tile < TILE_COUNT ? tile : TILE_UNKNOWN];
+    SDL_SetRenderDrawColor(r, c.r, c.g, c.b, c.a);
+}
+
+void set_biome_color(SDL_Renderer* r, BiomeType biome) {
+    SDL_Color c = biome_colors[biome < BIOME_COUNT ? biome : BIOME_UNKNOWN];
     SDL_SetRenderDrawColor(r, c.r, c.g, c.b, c.a);
 }
 

--- a/src/functions/ui/ui.h
+++ b/src/functions/ui/ui.h
@@ -14,5 +14,6 @@ void render_debug_terminal(SDL_Renderer* renderer, TTF_Font* font, int screen_w,
 const char* biome_to_string(BiomeType biome);
 
 void set_tile_color(SDL_Renderer* r, TileID tile);
+void set_biome_color(SDL_Renderer* r, BiomeType biome);
 
 #endif

--- a/src/include/structure.h
+++ b/src/include/structure.h
@@ -191,4 +191,23 @@ typedef enum {
     BIOME_UNKNOWN
 } BiomeType;
 
+#define BIOME_COUNT (BIOME_UNKNOWN + 1)
+
+static SDL_Color biome_colors[BIOME_COUNT] = {
+    [BIOME_FOREST]     = { 34, 139,  34, 255 },
+    [BIOME_DESERT]     = {237, 201, 175, 255 },
+    [BIOME_MOUNTAIN]   = {139, 137, 137, 255 },
+    [BIOME_WATER]      = { 30, 144, 255, 255 },
+    [BIOME_SNOW]       = {255, 250, 250, 255 },
+    [BIOME_PLAINS]     = {144, 238, 144, 255 },
+    [BIOME_SWAMP]      = { 47,  79,  79, 255 },
+    [BIOME_JUNGLE]     = {  0, 100,   0, 255 },
+    [BIOME_VOLCANIC]   = {178,  34,  34, 255 },
+    [BIOME_CLOUD]      = {245, 245, 245, 255 },
+    [BIOME_HEAVEN]     = {255, 255, 224, 255 },
+    [BIOME_UNDERWORLD] = {105,   0, 105, 255 },
+    [BIOME_SACRED]     = {186,  85, 211, 255 },
+    [BIOME_UNKNOWN]    = { 60,  60,  60, 255 }
+};
+
 #endif


### PR DESCRIPTION
## Summary
- Define a palette for each biome and expose BIOME_COUNT
- Ensure biomes cover at least 200×200 tiles via BIOME_SIZE
- Render minimap using biome colors and add tile variants for multiple biomes

## Testing
- `cmake -S . -B build` *(fails: Could not find SDL2 package)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c7cc236f88333b0945017b9cefe9e