### PR TITLE
Remove map noise and unify debug naming

### DIFF
--- a/src/functions/debug/debug.c
+++ b/src/functions/debug/debug.c
@@ -14,32 +14,32 @@ void debug_clear() {
 void debug_terminal_log(const char* fmt, ...) {
     if (debug_line_count >= DEBUG_BUFFER_LINES) {
         // shift lines (scroll)
-        for (int i = 1; i < DEBUG_BUFFER_LINES; i++) {
-            strcpy(debug_lines[i - 1], debug_lines[i]);
+        for (int debug_i = 1; debug_i < DEBUG_BUFFER_LINES; debug_i++) {
+            strcpy(debug_lines[debug_i - 1], debug_lines[debug_i]);
         }
         debug_line_count = DEBUG_BUFFER_LINES - 1;
     }
 
-    va_list args;
-    va_start(args, fmt);
-    vsnprintf(debug_lines[debug_line_count++], 128, fmt, args);
-    va_end(args);
+    va_list debug_args;
+    va_start(debug_args, fmt);
+    vsnprintf(debug_lines[debug_line_count++], 128, fmt, debug_args);
+    va_end(debug_args);
 }
 
-void debug_render_in_rect(SDL_Renderer *renderer, TTF_Font *font, SDL_Rect rect) {
-    SDL_Color white = {255, 255, 255, 255};
-    for (int i = 0; i < debug_line_count; i++) {
-        SDL_Surface *surface = TTF_RenderUTF8_Blended(font, debug_lines[i], white);  // UTF-8
-        SDL_Texture *texture = SDL_CreateTextureFromSurface(renderer, surface);
-        SDL_Rect dst = {
-            rect.x + 10,
-            rect.y + 10 + i * 20,
-            surface->w,
-            surface->h
+void debug_render_in_rect(SDL_Renderer *renderer, TTF_Font *font, SDL_Rect debug_rect) {
+    SDL_Color debug_white = {255, 255, 255, 255};
+    for (int debug_i = 0; debug_i < debug_line_count; debug_i++) {
+        SDL_Surface *debug_surface = TTF_RenderUTF8_Blended(font, debug_lines[debug_i], debug_white);
+        SDL_Texture *debug_texture = SDL_CreateTextureFromSurface(renderer, debug_surface);
+        SDL_Rect debug_dst = {
+            debug_rect.x + 10,
+            debug_rect.y + 10 + debug_i * 20,
+            debug_surface->w,
+            debug_surface->h
         };
-        SDL_RenderCopy(renderer, texture, NULL, &dst);
-        SDL_FreeSurface(surface);
-        SDL_DestroyTexture(texture);
+        SDL_RenderCopy(renderer, debug_texture, NULL, &debug_dst);
+        SDL_FreeSurface(debug_surface);
+        SDL_DestroyTexture(debug_texture);
     }
 }
 
@@ -47,11 +47,11 @@ extern int debug_terminal_mode;
 
 void execute_debug_command(const char* cmd, Player* player) {
     if (strncmp(cmd, "tp ", 3) == 0) {
-        int x, y;
-        if (sscanf(cmd + 3, "%d %d", &x, &y) == 2) {
-            player->pos_x = x * TILE_SIZE;
-            player->pos_y = y * TILE_SIZE;
-            debug_terminal_log("    Teleportation a (%d %d)", x, y);
+        int debug_x, debug_y;
+        if (sscanf(cmd + 3, "%d %d", &debug_x, &debug_y) == 2) {
+            player->pos_x = debug_x * TILE_SIZE;
+            player->pos_y = debug_y * TILE_SIZE;
+            debug_terminal_log("    Teleportation a (%d %d)", debug_x, debug_y);
         } else {
             debug_terminal_log("    Syntaxe invalide : tp x y");
         }

--- a/src/functions/elements/elements.c
+++ b/src/functions/elements/elements.c
@@ -1,106 +1,18 @@
 #include "../../include/global.h"
 
-// Simple internal definitions for two biomes
-static TileVariant desert_tiles[] = {
-    { TILE_SAND, 0.7f },
-    { TILE_ROCK, 0.2f },
-    { TILE_CACTUS, 0.1f }
-};
-
-static TileVariant forest_tiles[] = {
-    { TILE_GRASS, 0.6f },
-    { TILE_TREE, 0.3f },
-    { TILE_ROCK, 0.1f }
-};
-
-static TileVariant plains_tiles[] = {
-    { TILE_GRASS, 0.8f },
-    { TILE_SOIL, 0.2f }
-};
-
-static TileVariant snow_tiles[] = {
-    { TILE_SNOW, 0.8f },
-    { TILE_ROCK, 0.2f }
-};
-
-static TileVariant mountain_tiles[] = {
-    { TILE_ROCK, 0.7f },
-    { TILE_SNOW, 0.3f }
-};
-
-static TileVariant water_tiles[] = {
-    { TILE_WATER, 1.0f }
-};
-
 TileVariant get_tile_variant_for_biome(BiomeType biome, int x, int y) {
-    float r = noise2d(x * 0.2f, y * 0.2f);
-    TileVariant* variants = NULL;
-    int count = 0;
-
-    switch (biome) {
-        case BIOME_DESERT:
-            variants = desert_tiles;
-            count = sizeof(desert_tiles) / sizeof(TileVariant);
-            break;
-        case BIOME_FOREST:
-            variants = forest_tiles;
-            count = sizeof(forest_tiles) / sizeof(TileVariant);
-            break;
-        case BIOME_PLAINS:
-            variants = plains_tiles;
-            count = sizeof(plains_tiles) / sizeof(TileVariant);
-            break;
-        case BIOME_SNOW:
-            variants = snow_tiles;
-            count = sizeof(snow_tiles) / sizeof(TileVariant);
-            break;
-        case BIOME_MOUNTAIN:
-            variants = mountain_tiles;
-            count = sizeof(mountain_tiles) / sizeof(TileVariant);
-            break;
-        case BIOME_WATER:
-            variants = water_tiles;
-            count = sizeof(water_tiles) / sizeof(TileVariant);
-            break;
-        default:
-            return (TileVariant){ TILE_GRASS, 1.0f };
-    }
-
-    float total = 0.0f;
-    for (int i = 0; i < count; i++) {
-        total += variants[i].chance;
-        if (r <= total)
-            return variants[i];
-    }
-    return variants[count - 1];
+    (void)biome; (void)x; (void)y;
+    return (TileVariant){TILE_GRASS, 1.0f};
 }
 
 BiomeType get_biome_from_noise(float elevation, float humidity) {
-    if (elevation < 0.3f) return BIOME_WATER;
-    if (elevation < 0.5f) {
-        if (humidity > 0.6f) return BIOME_FOREST;
-        return BIOME_PLAINS;
-    }
-    if (elevation < 0.7f) return BIOME_DESERT;
-    if (elevation < 0.85f) return BIOME_MOUNTAIN;
-    return BIOME_SNOW;
+    (void)elevation; (void)humidity;
+    return BIOME_PLAINS;
 }
 
 const char* biome_to_string(BiomeType biome) {
     switch (biome) {
-        case BIOME_FOREST: return "Forest";
-        case BIOME_DESERT: return "Desert";
-        case BIOME_MOUNTAIN: return "Mountain";
-        case BIOME_WATER: return "Water";
-        case BIOME_SNOW: return "Snow";
         case BIOME_PLAINS: return "Plains";
-        case BIOME_SWAMP: return "Swamp";
-        case BIOME_JUNGLE: return "Jungle";
-        case BIOME_VOLCANIC: return "Volcanic";
-        case BIOME_CLOUD: return "Cloud";
-        case BIOME_HEAVEN: return "Heaven";
-        case BIOME_UNDERWORLD: return "Underworld";
-        case BIOME_SACRED: return "Sacred";
-        default: return "Unknown";
+        default: return "Plains";
     }
 }

--- a/src/functions/floor/floor.c
+++ b/src/functions/floor/floor.c
@@ -28,13 +28,13 @@ for (int y = start_y; y < end_y; ++y) {
 
 if (debug_mode) {
     SDL_SetRenderDrawColor(renderer, 90, 90, 90, 255);
-    for (int x = start_x; x <= end_x; ++x) {
-        int line_x = x * TILE_SIZE - camera.x;
-        SDL_RenderDrawLine(renderer, line_x, 0, line_x, camera.h);
+    for (int debug_x = start_x; debug_x <= end_x; ++debug_x) {
+        int debug_line_x = debug_x * TILE_SIZE - camera.x;
+        SDL_RenderDrawLine(renderer, debug_line_x, 0, debug_line_x, camera.h);
     }
-    for (int y = start_y; y <= end_y; ++y) {
-        int line_y = y * TILE_SIZE - camera.y;
-        SDL_RenderDrawLine(renderer, 0, line_y, camera.w, line_y);
+    for (int debug_y = start_y; debug_y <= end_y; ++debug_y) {
+        int debug_line_y = debug_y * TILE_SIZE - camera.y;
+        SDL_RenderDrawLine(renderer, 0, debug_line_y, camera.w, debug_line_y);
     }
 }
 

--- a/src/functions/map/map.c
+++ b/src/functions/map/map.c
@@ -48,15 +48,10 @@ bool generate_chunk(TileID tiles[CHUNK_SIZE][CHUNK_SIZE], int chunk_x, int chunk
     if (base_x >= MAP_WIDTH || base_y >= MAP_HEIGHT)
         return false;
 
-    // Generate chunk tiles with the new biome system
+    // Fill the chunk with a single background tile.
     for (int y = 0; y < CHUNK_SIZE; y++) {
         for (int x = 0; x < CHUNK_SIZE; x++) {
-            int global_x = base_x + x;
-            int global_y = base_y + y;
-
-            BiomeType biome = get_biome_at(global_x, global_y);
-            TileVariant variant = get_tile_variant_for_biome(biome, global_x, global_y);
-            tiles[y][x] = variant.tile_id;
+            tiles[y][x] = TILE_GRASS;
         }
     }
 

--- a/src/functions/map/map_noise.c
+++ b/src/functions/map/map_noise.c
@@ -1,125 +1,36 @@
-// Implementation of 2D Perlin noise with fBm helpers.
-#include <math.h>
-#include <stdlib.h>
 #include "../../include/global.h"
 
-static const unsigned char base_perm[256] = {
-    151,160,137,91,90,15,131,13,201,95,96,53,194,233,7,225,140,36,103,30,
-    69,142,8,99,37,240,21,10,23,190,6,148,247,120,234,75,0,26,197,62,94,
-    252,219,203,117,35,11,32,57,177,33,88,237,149,56,87,174,20,125,136,171,
-    168,68,175,74,165,71,134,139,48,27,166,77,146,158,231,83,111,229,122,60,
-    211,133,230,220,105,92,41,55,46,245,40,244,102,143,54,65,25,63,161,1,
-    216,80,73,209,76,132,187,208,89,18,169,200,196,135,130,116,188,159,86,
-    164,100,109,198,173,186,3,64,52,217,226,250,124,123,5,202,38,147,118,
-    126,255,82,85,212,207,206,59,227,47,16,58,17,182,189,28,42,223,183,170,
-    213,119,248,152,2,44,154,163,70,221,153,101,155,167,43,172,9,129,22,39,
-    253,19,98,108,110,79,113,224,232,178,185,112,104,218,246,97,228,251,34,
-    242,193,238,210,144,12,191,179,162,241,81,51,145,235,249,14,239,107,49,
-    192,214,31,181,199,106,157,184,84,204,176,115,121,50,45,127,4,150,254,
-    138,236,205,93,222,114,67,29,24,72,243,141,128,195,78,66,215,61,156,180
-};
-
-static unsigned char perm[512];
-static int perm_initialized = 0;
-
-static void init_perm(void) {
-    for (int i = 0; i < 256; ++i) {
-        perm[i] = perm[256 + i] = base_perm[i];
-    }
-    perm_initialized = 1;
-}
-
-static float lerp(float a, float b, float t) {
-    return a + t * (b - a);
-}
-
-static float fade(float t) {
-    return t * t * t * (t * (t * 6 - 15) + 10);
-}
-
-static float grad(int hash, float x, float y) {
-    switch (hash & 7) {
-        case 0: return  x + y;
-        case 1: return -x + y;
-        case 2: return  x - y;
-        case 3: return -x - y;
-        case 4: return  x;
-        case 5: return -x;
-        case 6: return  y;
-        default: return -y;
-    }
-}
-
 float noise2d(float x, float y) {
-    if (!perm_initialized) init_perm();
-
-    int X = (int)floorf(x) & 255;
-    int Y = (int)floorf(y) & 255;
-
-    x -= floorf(x);
-    y -= floorf(y);
-
-    float u = fade(x);
-    float v = fade(y);
-
-    int A = perm[X] + Y;
-    int B = perm[X + 1] + Y;
-
-    float res = lerp(
-        lerp(grad(perm[A], x, y),
-             grad(perm[B], x - 1, y), u),
-        lerp(grad(perm[A + 1], x, y - 1),
-             grad(perm[B + 1], x - 1, y - 1), u),
-        v);
-
-    return (res + 1.0f) * 0.5f; // normalized [0,1]
+    (void)x; (void)y;
+    return 0.0f;
 }
 
 float fbm(float x, float y, int octaves, float persistence, float scale) {
-    float total = 0.0f;
-    float amplitude = 1.0f;
-    float max_value = 0.0f;
-    float frequency = scale;
+    (void)x; (void)y; (void)octaves; (void)persistence; (void)scale;
+    return 0.0f;
+}
 
-    for (int i = 0; i < octaves; i++) {
-        total += noise2d(x * frequency, y * frequency) * amplitude;
-        max_value += amplitude;
-
-        amplitude *= persistence;
-        frequency *= 2.0f;
-    }
-
-    return max_value > 0.0f ? total / max_value : 0.0f;
+float get_height(int x, int y) {
+    (void)x; (void)y;
+    return 0.0f;
 }
 
 NoiseSample get_noise_sample(int x, int y) {
-    float fx = (float)x + 0.5f;
-    float fy = (float)y + 0.5f;
-
-    NoiseSample sample;
-    sample.x = fx;
-    sample.y = fy;
-    sample.elevation = fbm(fx, fy, 5, 0.5f, 0.01f);
-    sample.humidity = noise2d(fx * 0.05f, fy * 0.05f);
-    sample.temperature = noise2d((fx + 5000) * 0.05f, (fy + 5000) * 0.05f);
+    NoiseSample sample = {0};
+    sample.x = (float)x;
+    sample.y = (float)y;
+    sample.elevation = 0.0f;
+    sample.humidity = 0.0f;
+    sample.temperature = 0.0f;
     return sample;
 }
 
 BiomeType get_biome_from_sample(NoiseSample sample) {
-    return get_biome_from_noise(sample.elevation, sample.humidity);
-}
-
-// --- Main interface ---
-float get_height(int x, int y) {
-    return fbm((float)x / 50.0f, (float)y / 50.0f, 5, 0.5f, 0.01f);
+    (void)sample;
+    return BIOME_PLAINS;
 }
 
 BiomeType get_biome_at(int x, int y) {
-    int bx = x / BIOME_SIZE;
-    int by = y / BIOME_SIZE;
-    int sample_x = bx * BIOME_SIZE + BIOME_SIZE / 2;
-    int sample_y = by * BIOME_SIZE + BIOME_SIZE / 2;
-    NoiseSample sample = get_noise_sample(sample_x, sample_y);
-    NoiseSample sample = get_noise_sample(sample_x, sample_y);
-    return get_biome_from_sample(sample);
+    (void)x; (void)y;
+    return BIOME_PLAINS;
 }

--- a/src/functions/ui/ui.c
+++ b/src/functions/ui/ui.c
@@ -1,101 +1,96 @@
 #include "../../include/global.h"
 
-void render_fps(SDL_Renderer* renderer, TTF_Font* font, int fps) {
-    // Static variables to cache the texture
-    static int last_fps = -1;
-    static SDL_Texture* fpsTexture = NULL;
-    static char cachedText[32] = "";
-    SDL_Color white = {255, 255, 255, 255};
+void render_fps(SDL_Renderer* renderer, TTF_Font* font, int debug_fps) {
+    static int debug_last_fps = -1;
+    static SDL_Texture* debug_fps_texture = NULL;
+    static char debug_cached_text[32] = "";
+    SDL_Color debug_white = {255, 255, 255, 255};
 
-    // Update the texture only if the FPS has changed
-    if (fps != last_fps) {
-        last_fps = fps;
-        snprintf(cachedText, sizeof(cachedText), "FPS: %d", fps);
-        if (fpsTexture) {
-            SDL_DestroyTexture(fpsTexture);
-            fpsTexture = NULL;
+    if (debug_fps != debug_last_fps) {
+        debug_last_fps = debug_fps;
+        snprintf(debug_cached_text, sizeof(debug_cached_text), "FPS: %d", debug_fps);
+        if (debug_fps_texture) {
+            SDL_DestroyTexture(debug_fps_texture);
+            debug_fps_texture = NULL;
         }
-        SDL_Surface* surface = TTF_RenderUTF8_Blended(font, cachedText, white);
-        if (surface) {
-            fpsTexture = SDL_CreateTextureFromSurface(renderer, surface);
-            SDL_FreeSurface(surface);
+        SDL_Surface* debug_surface = TTF_RenderUTF8_Blended(font, debug_cached_text, debug_white);
+        if (debug_surface) {
+            debug_fps_texture = SDL_CreateTextureFromSurface(renderer, debug_surface);
+            SDL_FreeSurface(debug_surface);
         }
     }
 
-    // Render the texture if it is available
-    if (fpsTexture) {
-        SDL_Rect dst;
-        SDL_QueryTexture(fpsTexture, NULL, NULL, &dst.w, &dst.h);
-        int win_w, win_h;
-        SDL_GetRendererOutputSize(renderer, &win_w, &win_h);
-        dst.x = win_w - dst.w - 10; // margin of 10 pixels
-        dst.y = 10;
-        SDL_RenderCopy(renderer, fpsTexture, NULL, &dst);
+    if (debug_fps_texture) {
+        SDL_Rect debug_dst;
+        SDL_QueryTexture(debug_fps_texture, NULL, NULL, &debug_dst.w, &debug_dst.h);
+        int debug_win_w, debug_win_h;
+        SDL_GetRendererOutputSize(renderer, &debug_win_w, &debug_win_h);
+        debug_dst.x = debug_win_w - debug_dst.w - 10;
+        debug_dst.y = 10;
+        SDL_RenderCopy(renderer, debug_fps_texture, NULL, &debug_dst);
     }
-
 }
 
-void render_minimap(SDL_Renderer* renderer, float player_pos_x, float player_pos_y) {
-    const Chunk* chunk_cache = get_chunk_cache();
-    const int TILE_PIXEL = 2;
-    const int MARGIN_X = 10;
-    const int MARGIN_Y = 10;
-    const int RADIUS_TILES = 50;
+void render_minimap(SDL_Renderer* renderer, float debug_player_pos_x, float debug_player_pos_y) {
+    const Chunk* debug_chunk_cache = get_chunk_cache();
+    const int debug_tile_pixel = 2;
+    const int debug_margin_x = 10;
+    const int debug_margin_y = 10;
+    const int debug_radius_tiles = 50;
 
-    int center_tile_x = (int)(player_pos_x / TILE_SIZE);
-    int center_tile_y = (int)(player_pos_y / TILE_SIZE);
+    int debug_center_tile_x = (int)(debug_player_pos_x / TILE_SIZE);
+    int debug_center_tile_y = (int)(debug_player_pos_y / TILE_SIZE);
 
-    // black background with border
-    SDL_Rect bg = {
-        MARGIN_X - 1,
-        MARGIN_Y - 1,
-        (2 * RADIUS_TILES + 1) * TILE_PIXEL + 2,
-        (2 * RADIUS_TILES + 1) * TILE_PIXEL + 2
+    SDL_Rect debug_bg = {
+        debug_margin_x - 1,
+        debug_margin_y - 1,
+        (2 * debug_radius_tiles + 1) * debug_tile_pixel + 2,
+        (2 * debug_radius_tiles + 1) * debug_tile_pixel + 2
     };
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
-    SDL_RenderFillRect(renderer, &bg);
-    SDL_RenderDrawRect(renderer, &bg);
+    SDL_RenderFillRect(renderer, &debug_bg);
+    SDL_RenderDrawRect(renderer, &debug_bg);
 
-    for (int i = 0; i < CHUNK_CACHE_SIZE; i++) {
-        if (!chunk_cache[i].loaded) continue;
+    for (int debug_i = 0; debug_i < CHUNK_CACHE_SIZE; debug_i++) {
+        if (!debug_chunk_cache[debug_i].loaded) continue;
 
-        for (int y = 0; y < CHUNK_SIZE; y++) {
-            for (int x = 0; x < CHUNK_SIZE; x++) {
-                int global_x = chunk_cache[i].chunk_x * CHUNK_SIZE + x;
-                int global_y = chunk_cache[i].chunk_y * CHUNK_SIZE + y;
+        for (int debug_y = 0; debug_y < CHUNK_SIZE; debug_y++) {
+            for (int debug_x = 0; debug_x < CHUNK_SIZE; debug_x++) {
+                int global_x = debug_chunk_cache[debug_i].chunk_x * CHUNK_SIZE + debug_x;
+                int global_y = debug_chunk_cache[debug_i].chunk_y * CHUNK_SIZE + debug_y;
 
                 if (global_x < 0 || global_y < 0 || global_x >= MAP_WIDTH || global_y >= MAP_HEIGHT)
                     continue;
 
-                int dx = global_x - center_tile_x;
-                int dy = global_y - center_tile_y;
-                if (dx < -RADIUS_TILES || dx > RADIUS_TILES || dy < -RADIUS_TILES || dy > RADIUS_TILES)
+                int debug_dx = global_x - debug_center_tile_x;
+                int debug_dy = global_y - debug_center_tile_y;
+                if (debug_dx < -debug_radius_tiles || debug_dx > debug_radius_tiles ||
+                    debug_dy < -debug_radius_tiles || debug_dy > debug_radius_tiles)
                     continue;
 
-                SDL_Rect rect = {
-                    MARGIN_X + (dx + RADIUS_TILES) * TILE_PIXEL,
-                    MARGIN_Y + (dy + RADIUS_TILES) * TILE_PIXEL,
-                    TILE_PIXEL,
-                    TILE_PIXEL
+                SDL_Rect debug_rect = {
+                    debug_margin_x + (debug_dx + debug_radius_tiles) * debug_tile_pixel,
+                    debug_margin_y + (debug_dy + debug_radius_tiles) * debug_tile_pixel,
+                    debug_tile_pixel,
+                    debug_tile_pixel
                 };
 
-                BiomeType biome = get_biome_at(global_x, global_y);
-                set_biome_color(renderer, biome);
+                BiomeType debug_biome = get_biome_at(global_x, global_y);
+                set_biome_color(renderer, debug_biome);
 
-                SDL_RenderFillRect(renderer, &rect);
+                SDL_RenderFillRect(renderer, &debug_rect);
             }
         }
     }
 
-    // Player marker at the center
-    SDL_Rect marker = {
-        MARGIN_X + RADIUS_TILES * TILE_PIXEL,
-        MARGIN_Y + RADIUS_TILES * TILE_PIXEL,
-        TILE_PIXEL,
-        TILE_PIXEL
+    SDL_Rect debug_marker = {
+        debug_margin_x + debug_radius_tiles * debug_tile_pixel,
+        debug_margin_y + debug_radius_tiles * debug_tile_pixel,
+        debug_tile_pixel,
+        debug_tile_pixel
     };
     SDL_SetRenderDrawColor(renderer, 255, 0, 0, 255);
-    SDL_RenderFillRect(renderer, &marker);
+    SDL_RenderFillRect(renderer, &debug_marker);
 }
 
 void set_tile_color(SDL_Renderer* r, TileID tile) {
@@ -112,35 +107,34 @@ extern int debug_terminal_mode;
 extern char debug_input[128];
 extern int debug_input_len;
 
-void render_debug_terminal(SDL_Renderer* renderer, TTF_Font* font, int w, int h, int cam_x, int cam_y) {
-    SDL_Rect rect = {0, h - h / 4, w / 2, h / 4};
+void render_debug_terminal(SDL_Renderer* renderer, TTF_Font* font, int debug_w, int debug_h, int debug_cam_x, int debug_cam_y) {
+    SDL_Rect debug_rect = {0, debug_h - debug_h / 4, debug_w / 2, debug_h / 4};
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 220);
-    SDL_RenderFillRect(renderer, &rect);
+    SDL_RenderFillRect(renderer, &debug_rect);
 
-    SDL_Rect log_rect = rect;
-    log_rect.h -= 30;  // Leave room for input
-    debug_render_in_rect(renderer, font, log_rect);
+    SDL_Rect debug_log_rect = debug_rect;
+    debug_log_rect.h -= 30;
+    debug_render_in_rect(renderer, font, debug_log_rect);
 
-    SDL_Color color = {255, 255, 255, 255};
-    char buffer[256];
+    SDL_Color debug_color = {255, 255, 255, 255};
+    char debug_buffer[256];
 
     if (debug_terminal_mode) {
-        snprintf(buffer, sizeof(buffer), "> %s", debug_input);
+        snprintf(debug_buffer, sizeof(debug_buffer), "> %s", debug_input);
     } else {
-        snprintf(buffer, sizeof(buffer), "Pos: (%d,%d)  Chunks: %d", cam_x, cam_y, get_chunk_count());
+        snprintf(debug_buffer, sizeof(debug_buffer), "Pos: (%d,%d)  Chunks: %d", debug_cam_x, debug_cam_y, get_chunk_count());
     }
 
-
-    SDL_Surface* surf = TTF_RenderUTF8_Blended(font, buffer, color);
-    SDL_Texture* tex = SDL_CreateTextureFromSurface(renderer, surf);
-    SDL_Rect text_rect = {
-        rect.x + 10,
-        rect.y + rect.h - surf->h - 5,
-        surf->w,
-        surf->h
+    SDL_Surface* debug_surf = TTF_RenderUTF8_Blended(font, debug_buffer, debug_color);
+    SDL_Texture* debug_tex = SDL_CreateTextureFromSurface(renderer, debug_surf);
+    SDL_Rect debug_text_rect = {
+        debug_rect.x + 10,
+        debug_rect.y + debug_rect.h - debug_surf->h - 5,
+        debug_surf->w,
+        debug_surf->h
     };
 
-    SDL_RenderCopy(renderer, tex, NULL, &text_rect);
-    SDL_FreeSurface(surf);
-    SDL_DestroyTexture(tex);
+    SDL_RenderCopy(renderer, debug_tex, NULL, &debug_text_rect);
+    SDL_FreeSurface(debug_surf);
+    SDL_DestroyTexture(debug_tex);
 }

--- a/src/functions/ui/ui.h
+++ b/src/functions/ui/ui.h
@@ -7,9 +7,9 @@
 #include "../../include/structure.h"
 
 // Display FPS in the top-left corner of the screen
-void render_fps(SDL_Renderer* renderer, TTF_Font* font, int fps);
-void render_minimap(SDL_Renderer* renderer, float player_pos_x, float player_pos_y);
-void render_debug_terminal(SDL_Renderer* renderer, TTF_Font* font, int screen_w, int screen_h, int cam_x, int cam_y);
+void render_fps(SDL_Renderer* renderer, TTF_Font* font, int debug_fps);
+void render_minimap(SDL_Renderer* renderer, float debug_player_pos_x, float debug_player_pos_y);
+void render_debug_terminal(SDL_Renderer* renderer, TTF_Font* font, int debug_screen_w, int debug_screen_h, int debug_cam_x, int debug_cam_y);
 
 const char* biome_to_string(BiomeType biome);
 

--- a/src/main.c
+++ b/src/main.c
@@ -79,9 +79,9 @@ if (debug_mode) {
 }
 
     // FPS variables
-    int frame_count = 0;
-    Uint32 last_time = SDL_GetTicks();
-    int fps = 0;
+    int debug_frame_count = 0;
+    Uint32 debug_last_time = SDL_GetTicks();
+    int debug_fps = 0;
     SDL_Event event;
     bool running = true;
 
@@ -160,16 +160,16 @@ if (debug_mode) {
         render_player(renderer, &player, &camera);
 
         // FPS calculation
-        frame_count++;
-        Uint32 current_time = SDL_GetTicks();
-        if (current_time - last_time >= 1000) {
-            fps = frame_count;
-            frame_count = 0;
-            last_time = current_time;
+        debug_frame_count++;
+        Uint32 debug_current_time = SDL_GetTicks();
+        if (debug_current_time - debug_last_time >= 1000) {
+            debug_fps = debug_frame_count;
+            debug_frame_count = 0;
+            debug_last_time = debug_current_time;
         }
 
 if (debug_mode) {
-    render_fps(renderer, font, fps);
+    render_fps(renderer, font, debug_fps);
     render_minimap(renderer, player.pos_x, player.pos_y);
     render_debug_terminal(renderer, font, screen_width, screen_height, camera.x, camera.y);
 }


### PR DESCRIPTION
## Summary
- Simplify map chunk generation to always use a single background tile
- Stub out noise and biome helpers to eliminate Perlin noise and map elements
- Prefix every debug-only variable with `debug_` and adjust UI helpers

## Testing
- `cmake -S . -B build` *(fails: could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_68a42da5dd4c8333b51a26f40d139a5b